### PR TITLE
Fix region langs not generating the correct values folder.

### DIFF
--- a/src/main/java/com/airsaid/localization/services/AndroidValuesService.java
+++ b/src/main/java/com/airsaid/localization/services/AndroidValuesService.java
@@ -193,7 +193,12 @@ public final class AndroidValuesService {
   }
 
   private String getValuesDirectoryName(@NotNull Lang lang) {
-    return "values-".concat(lang.getCode());
+    String[] parts = lang.getCode().split("-");
+    if (parts.length > 1) {
+      return "values-".concat(parts[0] + "-" + "r" + parts[1].toUpperCase());
+    } else {
+      return "values-".concat(lang.getCode());
+    }
   }
 
   /**


### PR DESCRIPTION
Format lang-region code for values folders as required by Android. ('es-es' -> 'es-rES')

https://developer.android.com/guide/topics/resources/providing-resources#AlternativeResources:

> 
> The language is defined by a two-letter [ISO 639-1](http://www.loc.gov/standards/iso639-2/php/code_list.php) language code, optionally followed by a two-letter [ISO 3166-1-alpha-2](https://www.iso.org/obp/ui/#iso:pub:PUB500001:en) region code (preceded by lowercase r).
> 
> The codes are not case-sensitive. The r prefix is used to distinguish the region portion. You can't specify a region alone.